### PR TITLE
validate: check all exported satisfiers for any given macaroon

### DIFF
--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -1,5 +1,4 @@
-import { originSatisfier } from './satisfiers'
 import TIME_CAVEAT_CONFIGS from './time'
 import ORIGIN_CAVEAT_CONFIGS from './origin'
 
-export { originSatisfier, TIME_CAVEAT_CONFIGS, ORIGIN_CAVEAT_CONFIGS }
+export { TIME_CAVEAT_CONFIGS, ORIGIN_CAVEAT_CONFIGS }

--- a/src/configs/origin.ts
+++ b/src/configs/origin.ts
@@ -7,7 +7,7 @@ import { Request } from 'express'
 import { BoltwallConfig, DescriptionGetter, CaveatGetter } from '../typings'
 
 import { Caveat } from 'lsat-js'
-import { originSatisfier } from '.'
+import { originSatisfier } from './satisfiers'
 import { getOriginFromRequest } from '../helpers'
 
 /**


### PR DESCRIPTION
This change allows known boltwall caveats to be added to any lsat that will be sent to a boltwall server. Satisfiers are run against all macaroons. If a caveat exists on a macaroon that boltwall recognizes (currently only time and origin), then it will be processed and rejected if not satisfied. This removes the need to add the satisfiers to the config ahead of time when launching boltwall. Adding additional satisfiers and caveat getters still supported.