### PR TITLE
invoice: update GET /invoice API to not require LSAT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Once the server is running, you can test the API:
 4. `POST http://localhost:5000/invoice` with the following JSON body to get a new invoice (there
    is no relation to any lsat and so cannot be used for authentication): `{ "amount": 30 }`
 
-5. `GET http://localhost:5000/invoice` with the appropriate LSAT in Authorization header (even with missing
-   payment hash) will return the status of the associated invoice
+5. `GET http://localhost:5000/invoice?id=[payment hash]` returns information for invoice with given
+   payment hash including payment status and payreq.
 
 Read more about the REST API in the [documentation](#documentation).
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -76,7 +76,7 @@ paths:
     get:
       summary: get status of a given invoice based on request LSAT
       description: |
-        Given an LSAT and invoice id, get the status of an invoice (i.e. is it paid or not)
+        Given an invoice id or a valid LSAT, get the status of an invoice (i.e. is it paid or not)
       operationId: getInvoice
       parameters:
         - in: query
@@ -94,6 +94,12 @@ paths:
                 $ref: "#/components/schemas/InvoiceResponse"
         "400":
           description: Missing invoice id, problem getting invoice
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorMessage"
+        "401":
+          description: Request sent with an invalid LSAT
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,6 +77,7 @@ paths:
       summary: get status of a given invoice based on request LSAT
       description: |
         Given an invoice id or a valid LSAT, get the status of an invoice (i.e. is it paid or not)
+        as well as payment information like payment request and id.
       operationId: getInvoice
       parameters:
         - in: query

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -79,15 +79,12 @@ paths:
         Given an LSAT and invoice id, get the status of an invoice (i.e. is it paid or not)
       operationId: getInvoice
       parameters:
-        - name: id
-          in: header
-          description: |
-            Hex encoded string of invoice id. Can be optional if request has a cookie that contains a root macaroon attached which should include data referencing an invoice id.
-          required: false
-          style: simple
-          explode: false
+        - in: query
+          name: id
           schema:
             type: string
+          required: true
+          description: hex encoded string of payment hash for looking up invoice
       responses:
         "200":
           description: Status of invoice and payreq string for reference
@@ -97,12 +94,6 @@ paths:
                 $ref: "#/components/schemas/InvoiceResponse"
         "400":
           description: Missing invoice id, problem getting invoice
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorMessage"
-        "401":
-          description: Request sent with an invalid LSAT
           content:
             application/json:
               schema:

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -282,8 +282,21 @@ This means payer can pay whatever they want for access.'
   }
   if (lnd) {
     let invoiceFunction = lnService.createInvoice
-    if (boltwallConfig && boltwallConfig.hodl)
+    const options = {
+      lnd: lnd,
+      description: _description,
+      expires_at: expiresAt,
+      tokens,
+      id: undefined,
+    }
+
+    if (boltwallConfig && boltwallConfig.hodl) {
+      const paymentHash = query.paymentHash || body.paymentHash
+      if (!paymentHash)
+        throw new Error('Require paymentHash to create HODL invoice')
       invoiceFunction = lnService.createHodlInvoice
+      options.id = paymentHash
+    }
 
     const {
       request: payreq,
@@ -291,12 +304,7 @@ This means payer can pay whatever they want for access.'
       description = _description,
       created_at: createdAt,
       tokens: amount,
-    } = await invoiceFunction({
-      lnd: lnd,
-      description: _description,
-      expires_at: expiresAt,
-      tokens,
-    })
+    } = await invoiceFunction(options)
     invoice = { payreq, id, description, createdAt, amount }
   } else if (opennode) {
     const {

--- a/src/routes/invoice.ts
+++ b/src/routes/invoice.ts
@@ -9,10 +9,8 @@ const router: Router = Router()
 /**
  * ## Route: GET /invoice
  * @description Get information about an invoice including status and secret. Request must be
- * authenticated with a macaroon. The handler will check for an LSAT and reject requests
- * without one since this is where the invoice id is extracted from. Supports requesting for invoice
- * based on hash in query parameter "id" OR from an attached LSAT. Valid and paid LSATs
- * will return secret in the information.
+ * authenticated with an LSAT if requesting secret. Supports requesting for invoice
+ * based on hash in query parameter "id" OR from an attached LSAT.
  */
 async function getInvoice(
   req: Request,

--- a/src/routes/invoice.ts
+++ b/src/routes/invoice.ts
@@ -1,34 +1,53 @@
 import { Response, Request, Router, NextFunction } from 'express'
+import { Lsat } from 'lsat-js'
 
 import { InvoiceResponse } from '../typings'
-// import { Lsat } from 'lsat-js'
-import { createInvoice, checkInvoiceStatus } from '../helpers'
-import { validateLsat } from '.'
+import { createInvoice, checkInvoiceStatus, isHex } from '../helpers'
+import validateLsat from './validate'
 const router: Router = Router()
 
 /**
  * ## Route: GET /invoice
  * @description Get information about an invoice including status and secret. Request must be
  * authenticated with a macaroon. The handler will check for an LSAT and reject requests
- * without one since this is where the invoice id is extracted from.
+ * without one since this is where the invoice id is extracted from. Supports requesting for invoice
+ * based on hash in query parameter "id" OR from an attached LSAT. Valid and paid LSATs
+ * will return secret in the information.
  */
 async function getInvoice(
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void | Response> {
-  const { id } = req.query
-  if (!id || id.length !== 64) {
+  let { id } = req.query
+  let lsat
+  if (req.headers.authorization) {
+    try {
+      lsat = Lsat.fromToken(req.headers.authorization)
+      if (lsat.paymentHash && !id) id = lsat.paymentHash
+    } catch (e) {
+      req.logger.warning(
+        'Failed to create an LSAT from authorization header: %s',
+        e.message || e
+      )
+    }
+  }
+
+  if (!id || id.length !== 64 || !isHex(id)) {
     res.status(400)
     return next({
       message:
-        'Missing valid payment hash in required query parameter "id" for looking up invoice',
+        'Bad Request: Missing valid payment hash in required query parameter "id" for looking up invoice',
     })
   }
 
   let invoice
   try {
-    invoice = await checkInvoiceStatus(id, req.lnd, req.opennode)
+    // if we have an LSAT included then it will have been validated already
+    // in an earlier middleware and we can include the secret (which will only
+    // be shown if it has been paid as well)
+    const includeSecret = lsat ? true : false
+    invoice = await checkInvoiceStatus(id, req.lnd, req.opennode, includeSecret)
   } catch (e) {
     // handle ln-service errors
     if (Array.isArray(e)) {

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -21,6 +21,7 @@ export default async function validateLsat(
   next: NextFunction
 ): Promise<void> {
   const { headers } = req
+
   // if hodl is enabled and there is not already an auth header
   // then we need to check if there is a paymentHash in the request body
   if (

--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -241,7 +241,7 @@ describe('helper functions', () => {
         is_confirmed: true,
         id: request.id,
         secret: invoice.secret,
-        tokens: 30,
+        tokens: request.tokens,
         created_at: '2016-08-29T09:12:33.001Z',
         description: request.description,
       }
@@ -257,7 +257,11 @@ describe('helper functions', () => {
     })
 
     it('should create an invoice using the amount provided in a request query', async () => {
-      const request = { lnd: {}, query: { amount: 50 }, body: {} }
+      const request = {
+        lnd: {},
+        query: { amount: invoiceResponse.tokens },
+        body: {},
+      }
 
       createInvStub
         .withArgs({


### PR DESCRIPTION
This is a change to the API to enable 3rd parties that know an invoice id to check on its status. Useful for applications such as split payments where the authorizing server wants to confirm that an invoice exists to pay which will return a preimage that can be used to redeem a hodl invoice. 

Also fixes bug where payment hash was not being passed to create a hodl invoice

Changes include:
* bug fixes to tests
* can either send invoice id in a query parameter OR make the request with an LSAT
* If a valid LSAT has been sent then the preimage will also be sent back in the response otherwise just the non-sensitive invoice details
* pass payment hash as ID to lnservice call to create hodl invoice